### PR TITLE
Add AI Invoice Generator CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
-# calendar
+# AI Invoice Generator
+
+This tool generates monthly invoices from Google Calendar events.
+
+## Requirements
+
+- Python 3.8+
+- `weasyprint`, `jinja2`, `google-api-python-client`, `google-auth`
+
+Install dependencies with:
+
+```bash
+pip install weasyprint jinja2 google-api-python-client google-auth
+```
+
+## Configuration
+
+Create a `config/` directory with:
+
+- `rates.yaml` – mapping of property names to hourly rates.
+- `service_account.json` – Google service account credentials with Calendar read access.
+- `invoice_template.html` – HTML template for invoices.
+
+Set `AI_INV_CONFIG_DIR` environment variable to point to this directory if different.
+
+## Usage
+
+```bash
+python -m invoice_generator.cli <calendar_id> <YYYY-MM>
+```
+
+PDF invoices will be written to `config/invoices/`.

--- a/config/invoice_template.html
+++ b/config/invoice_template.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <style>
+        body { font-family: sans-serif; }
+        table { width: 100%; border-collapse: collapse; }
+        th, td { border: 1px solid #ccc; padding: 4px; text-align: left; }
+    </style>
+</head>
+<body>
+    <h1>Invoice for {{ property }}</h1>
+    <p>Month: {{ month }}</p>
+    <table>
+        <tr><th>Hours</th><th>Rate</th><th>Total</th></tr>
+        <tr>
+            <td>{{ hours }}</td>
+            <td>${{ rate }}</td>
+            <td>${{ total }}</td>
+        </tr>
+    </table>
+</body>
+</html>

--- a/config/rates.yaml
+++ b/config/rates.yaml
@@ -1,0 +1,3 @@
+# property: hourly rate
+House A: 25
+House B: 30

--- a/invoice_generator/__init__.py
+++ b/invoice_generator/__init__.py
@@ -1,0 +1,1 @@
+"""AI Invoice Generator package"""

--- a/invoice_generator/__main__.py
+++ b/invoice_generator/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == "__main__":
+    main()

--- a/invoice_generator/aggregator.py
+++ b/invoice_generator/aggregator.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import calendar
+import datetime as dt
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Tuple
+
+from .parser import ParsedEvent
+from .config import config
+
+
+@dataclass
+class InvoiceItem:
+    property: str
+    month: str
+    hours: float
+    rate: float
+    total: float
+
+
+class Aggregator:
+    def __init__(self, events: Iterable[ParsedEvent]):
+        self.events = events
+
+    def group_by_property_month(self) -> List[InvoiceItem]:
+        grouped: Dict[Tuple[str, str], float] = defaultdict(float)
+        for event in self.events:
+            month = event.date.strftime("%Y-%m")
+            key = (event.property, month)
+            grouped[key] += event.hours
+        items = []
+        for (prop, month), hours in grouped.items():
+            rate = config.rate_table.get(prop, 0)
+            total = hours * rate
+            items.append(InvoiceItem(prop, month, hours, rate, total))
+        return items

--- a/invoice_generator/cli.py
+++ b/invoice_generator/cli.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+from typing import List
+
+from .fetcher import CalendarFetcher
+from .parser import parse_event_title
+from .aggregator import Aggregator
+from .invoice import InvoiceRenderer
+
+
+def run(calendar_id: str, month: str):
+    start = dt.datetime.fromisoformat(month + "-01")
+    end = (start + dt.timedelta(days=32)).replace(day=1)
+
+    fetcher = CalendarFetcher(calendar_id)
+    events = fetcher.fetch_events(start, end)
+
+    parsed = []
+    for ev in events:
+        result = parse_event_title(ev.summary)
+        if result:
+            parsed.append(result)
+
+    aggregator = Aggregator(parsed)
+    items = aggregator.group_by_property_month()
+
+    renderer = InvoiceRenderer()
+    renderer.render_invoices(items)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="AI Invoice Generator")
+    parser.add_argument("calendar_id", help="Google Calendar ID")
+    parser.add_argument("month", help="Month in YYYY-MM format")
+    args = parser.parse_args()
+    run(args.calendar_id, args.month)
+
+
+if __name__ == "__main__":
+    main()

--- a/invoice_generator/config.py
+++ b/invoice_generator/config.py
@@ -1,0 +1,25 @@
+import os
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+CONFIG_DIR = Path(os.getenv("AI_INV_CONFIG_DIR", Path.cwd()))
+RATE_FILE = CONFIG_DIR / "rates.yaml"
+SERVICE_ACCOUNT_FILE = CONFIG_DIR / "service_account.json"
+TEMPLATE_FILE = CONFIG_DIR / "invoice_template.html"
+OUTPUT_DIR = CONFIG_DIR / "invoices"
+
+
+class Config:
+    def __init__(self):
+        self.rate_table = self.load_rates()
+
+    def load_rates(self) -> dict:
+        if RATE_FILE.exists():
+            with open(RATE_FILE, "r", encoding="utf-8") as f:
+                return yaml.safe_load(f)
+        return {}
+
+
+config = Config()

--- a/invoice_generator/fetcher.py
+++ b/invoice_generator/fetcher.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass
+from typing import List
+
+from google.oauth2 import service_account
+from googleapiclient.discovery import build
+
+from .config import SERVICE_ACCOUNT_FILE
+
+SCOPES = ["https://www.googleapis.com/auth/calendar.readonly"]
+
+
+@dataclass
+class CalendarEvent:
+    summary: str
+    start: dt.datetime
+    end: dt.datetime
+
+
+class CalendarFetcher:
+    def __init__(self, calendar_id: str):
+        self.calendar_id = calendar_id
+        self.service = self._build_service()
+
+    def _build_service(self):
+        if not SERVICE_ACCOUNT_FILE.exists():
+            raise FileNotFoundError("Service account file not found")
+        creds = service_account.Credentials.from_service_account_file(
+            SERVICE_ACCOUNT_FILE, scopes=SCOPES
+        )
+        return build("calendar", "v3", credentials=creds, cache_discovery=False)
+
+    def fetch_events(
+        self, time_min: dt.datetime, time_max: dt.datetime
+    ) -> List[CalendarEvent]:
+        events_result = (
+            self.service.events()
+            .list(
+                calendarId=self.calendar_id,
+                timeMin=time_min.isoformat(),
+                timeMax=time_max.isoformat(),
+                singleEvents=True,
+                orderBy="startTime",
+            )
+            .execute()
+        )
+        events = []
+        for item in events_result.get("items", []):
+            start = item["start"].get("dateTime") or item["start"].get("date")
+            end = item["end"].get("dateTime") or item["end"].get("date")
+            events.append(
+                CalendarEvent(
+                    summary=item.get("summary", ""),
+                    start=dt.datetime.fromisoformat(start),
+                    end=dt.datetime.fromisoformat(end),
+                )
+            )
+        return events

--- a/invoice_generator/invoice.py
+++ b/invoice_generator/invoice.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import asdict
+from pathlib import Path
+from typing import Iterable
+
+from jinja2 import Environment, FileSystemLoader
+from weasyprint import HTML
+
+from .aggregator import InvoiceItem
+from .config import OUTPUT_DIR, TEMPLATE_FILE
+
+
+class InvoiceRenderer:
+    def __init__(self):
+        self.env = Environment(loader=FileSystemLoader(str(TEMPLATE_FILE.parent)))
+        self.template = self.env.get_template(TEMPLATE_FILE.name)
+        OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+    def render_invoices(self, items: Iterable[InvoiceItem]):
+        for item in items:
+            context = asdict(item)
+            html = self.template.render(**context)
+            file_name = f"{item.property}-{item.month}.pdf"
+            output_file = OUTPUT_DIR / file_name
+            HTML(string=html).write_pdf(output_file)
+            print(f"Generated {output_file}")

--- a/invoice_generator/parser.py
+++ b/invoice_generator/parser.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import datetime as dt
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class ParsedEvent:
+    property: str
+    date: dt.date
+    hours: float
+
+
+EVENT_REGEX = re.compile(
+    r"(?P<property>[\w\s]+)\s+(?P<date>\d{4}-\d{2}-\d{2})\s+(?P<hours>[\d.]+)h",
+    re.IGNORECASE,
+)
+
+
+def parse_event_title(title: str) -> Optional[ParsedEvent]:
+    match = EVENT_REGEX.search(title)
+    if not match:
+        return None
+    prop = match.group("property").strip()
+    date = dt.date.fromisoformat(match.group("date"))
+    hours = float(match.group("hours"))
+    return ParsedEvent(property=prop, date=date, hours=hours)


### PR DESCRIPTION
## Summary
- implement CLI and modules to fetch and parse calendar data
- aggregate data by property and month
- render PDF invoices using a template
- provide example rate table and template

## Testing
- `pip show weasyprint | head -n 3`
- `pip show google-api-python-client | head -n 3`

------
https://chatgpt.com/codex/tasks/task_e_6858fce3f854832eaa7b938c88d75bf9